### PR TITLE
Use drone_ready flag for score

### DIFF
--- a/auav_2022_sample/scripts/referee.py
+++ b/auav_2022_sample/scripts/referee.py
@@ -29,6 +29,9 @@ class Referee:
 
     def rover_callback(self, odom):
         """score when we see the rover, use last known drone position"""
+        if not self.drone_ready:
+            return
+        
         self.rover_position = odom.pose.pose.position
 
         # if time expired


### PR DESCRIPTION
The script for calculating score points didn't wait for drone to be ready. The drone_ready flag was set in callback, but it was never used in the script code (referee.py). Flag is now checked before calculating score points and publishing it.